### PR TITLE
Fix compare function

### DIFF
--- a/src/MailPolicyExplainer.psm1
+++ b/src/MailPolicyExplainer.psm1
@@ -964,8 +964,8 @@ Function Test-MtaStsPolicy
 		# Split it up two different ways and see if we get the same results.
 		# If not, then someone probably saved the file with UNIX ("`r") endings.
 		# We're going to be strict and refuse to parse the file in this case.
-		$lines   = $policy.Content.Split("`r`n")
-		$LFlines = $policy.Content -Split "`r?`n"
+		$lines   = $policy.Content -Split "`r`n"
+		$LFlines = $policy.Content -Split "`n"
 
 		If ($lines.Count -ne $LFLines.Count) {
 			Write-Debug "This file has $($lines.Count) CRLF-terminated lines and $($LFlines.Count) LF-terminated lines."


### PR DESCRIPTION
I just implemented MTA-STS in my domain and using PowerShell 5.1, found I was always seeing the following error, even though my `mta-sta.txt` file was properly formatted with CRLF.

 `MTA-STS Policy: The policy file does not have the correct CRLF line endings!`

Confirmed the same behavior running `Test-MtaStsPolicy microsoft.com`