### PR TITLE
Add easy parameter to check ExO DKIM selectors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # MailPolicyExplainer Change Log
 
-## Version 1.4.2 (Saturday, February 15, 2025)
+## Version 1.5 (Saturday, February 15, 2025)
+- **NEW** The new parameter `Test-MailPolicy -ExchangeOnlineDkim` is now a synonym for `Test-MailPolicy -DkimSelectorsToCheck selector1,selector2`.  Additional DKIM selectors can still be specified like always.
 - **FIX** Fixed a bug where Sender ID records in `include:` tokens would be parsed in addition to SPF records, when doing recursive SPF or Sender ID checks.
 - **FIX** Fixed bugs where the word "SPF" would be printed during Sender ID checks.
 - **FIX** Fixed a bug preventing the `Test-SenderIdRecords` alias from checking Sender ID records.  Instead, it would check SPF records.

--- a/MailPolicyExplainer.psd1
+++ b/MailPolicyExplainer.psd1
@@ -24,7 +24,7 @@ with this program.  If not, see <https://www.gnu.org/licenses/>.
 RootModule = 'src/MailPolicyExplainer.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.4.2'
+ModuleVersion = '1.5.0'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Core', 'Desktop')
@@ -104,6 +104,7 @@ FileList = @(
 	'LICENSE.txt',
 	'MailPolicyExplainer.psd1',
 	'NEWS.md',
+	'ONEWS.md',
 	'README.md',
 	'SECURITY.md'
 )
@@ -122,7 +123,7 @@ PrivateData = @{
 			'MTA-STS', 'MX', 'TLSRPT', 'STARTTLS', 'domainkey', 'TLS', 'TLSA',
 			'ADSP',  'DNS', 'policy', 'SenderID', 'tester', 'Reporting', 'Test',
 			'Exchange', 'Office365', 'Google', 'Network', 'Cloud', 'security',
-			'audit', 'IPv4', 'IPv6', 'SMTP', 'RSA', 'Ed25519',
+			'audit', 'IPv4', 'IPv6', 'SMTP', 'RSA', 'Ed25519', 'ExchangeOnline',
 			'Windows', 'MacOS', 'Linux', 'PSEdition_Core', 'PSEdition_Desktop'
 		)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,66 +1,19 @@
 # MailPolicyExplainer News
+What's new in version 1.5?
 
-## Version 1.4.2
-This version is still in development and contains many fixes related to Sender ID checks (the so-called successor to SPF that never took off, but is still around for some reason).
+## Quicker Exchange Online DKIM checks
+For everyone supporting Exchange Online environments, it's such a pain to type out `Test-MailPolicy -DkimSelectorsToCheck selector1,selector2`, even with tab completion!  Now, you can use a quicker synonym:  `Test-MailPolicy -ExchangeOnlineDkim` (which you can tab-complete to your heart's content!).  Of course, you can still use `-DkimSelectorsToCheck` to check additional selectors for other services.
 
-## Version 1.4.1
-This was released on Wednesday, May 22, 2024.  Friend of the module [Jason Berry](https://github.com/skyblaster) [found and corrected a bug](https://github.com/rhymeswithmogul/MailPolicyExplainer/pull/3) a bug where the DMARC percentage (the `pct` token) was not being explained.
+## Better support for Sender ID records
+From the "rearranging deck chairs on the Titanic" department, this version contains several fixes to Sender ID lookups (you know, the `spf2.0` thing that Microsoft tried to shove down our throats in the early 2000's).
 
-## Version 1.4.0
-This was released on Thursday, April 4, 2024.  It's dedicated to Mimi (2006-2024), the best cat and a very good girl.
+- Firstly, `Test-SenderIdRecord` may not have been exported at all.
+- Even if it was, it only checked SPF records.
+- Even if it did work as intended, it still used the word "SPF" when it meant "Sender ID".
+- Secondly, when doing recursive lookups, SPF and Sender ID records would get mixed together when things `include:`d published both.  This was annoying at best, and it mistakenly countd more DNS lookups than actually happened.
 
-New features:
- - Most cmdlets now have a `-DisableDnssecVerification` switch that will disable all DNSSEC checks.  While it is still a best practice, maybe your DNS host doesn't support it (for some reason) and you'd like this cmdlet not to nag you every time.  Note that DNSSEC checks are still done for DANE records, as the former is a prerequisite for the latter, whether this switch is specified or not.
- - `Test-DkimRecord` will print the full DKIM TXT record to the verbose stream (i.e., the one that's visible when using `-Verbose` or setting the appropriate `$VerbosePreference` value).  Thanks to [Jason Berry](https://github.com/skyblaster) for writing [the pull request](https://github.com/rhymeswithmogul/MailPolicyExplainer/pull/1)!
+All of this has been corrected.
 
-Two bugs were fixed:
- - The SPF parser would sometimes show IPv4 addresses with a character prepended;  for example, "Accept mail from the IPv4 address +192.0.2.1" or "Reject mail from the IPv4 address -192.0.2.2".  This has been corrected by fixing the parser.
- - DNSSEC status is now shown even when records are not found.  DNSSEC is checked even records do not exist, in what's called authenticated denial of existence, so we should communicate it to the user regardless.
- - MTA-STS policy files are parsed to make sure they contain CR+LF line endings, but this did not work correctly on Windows PowerShell 5.1.  Thanks to [Jason Berry](https://github.com/skyblaster) for reporting it [and fixing it, too](https://github.com/rhymeswithmogul/MailPolicyExplainer/pull/2)!
+## Cleaning up the news file
+Older news can be found in the ONEWS.md (old news) file.
 
-## Version 1.3.4
-This was released on Wednesday, January 24, 2024.
-
-This is a bugfix release.  Due to a tiny syntax error, this module was not loading on Windows PowerShell 5.1.  This has been corrected.  PowerShell 7 was not affected.  Thank you to Aslan Grealis for pointing this out.
-
-## Version 1.3.3
-This was released on Thursday, January 17, 2024.
-
-This is a bugfix release.  When no DANE records are present for a domain with a single MX host, `Test-DaneRecords` would erroneously report the domain name when it should have reported the MX server name.  For example, "DANE records are not present for contoso.com" instead of "DANE records are not present for mail.contoso.com".  The non-existence of DANE records was reported correctly, though the error message was confusing.
-
-## Version 1.3.2
-This was released on Friday, December 8, 2023.
-
-This is a bugfix release.  Now, `Test-MtaStsPolicy` no longer misidentifies `mta-sts.txt` files with the correct CRLF line endings as malformed.  This was caused by a regression in version 1.3.1.
-
-## Version 1.3.1
-This was released on Wednesday, December 6, 2023.
-
-The output of `Test-IPVersions` is now indented when run from `Test-MxRecord` or `Test-MailPolicy`.  This ought to make things a little easier to read.
-
-More importantly, almost a dozen bugs have been squashed!
-
-## Version 1.3.0
-This was released on Tuesdsay, November 7, 2023.
-
-The SPF test now supports a new parameter, `-CountDnsLookups`, to test an SPF record recursively to ensure that no more than ten additional DNS lookups are required to evaluate SPF for a domain.  This can be invoked by either `Test-SpfRecord -CountDnsLookups` or `Test-MailPolicy -CountSpfDnsLookups`.  (`-Recurse` is an easy-to-remember alias for both cmdlets).
-
-In addition, a few bugs have also been squished -- namely, one that prevented conceptual help from being made available.
-
-## Version 1.2.0
-This was also released on Thursday, October 19, 2023.
-
-The SPF test now follows the `redirect=` modifier's value.  For example, if domainA.com has `v=spf1 redirect=domainB.com`, the module will analyze domainB.com's SPF record.  (Previously, the `redirect=` test was non-functional.)  Note that this behavior was reversed in version 1.3.0.
-
-## Version 1.1.0
-This was released on Thursday, October 19, 2023.
-
-### New features
-MX records and MTA-STS policy servers are now checked to make sure they are reachable over both IPv4 and IPv6.  This will ensure that all Internet users, including those who only have one protocol, can still access your server.
-
-### Bug Fixes
-- DKIM records may safely omit the `v=DKIM1` and `k=rsa` tokens.  This module, however, did not recognize those as valid.  These default values are now allowed to be missing, and substituted with appropriate defaults, per the RFC.
-- DKIM RSA keys larger than 4,096 bits now generate a warning, as they are not required to be supported by all validators.
-
-## Version 1.0.0
-This module was first released to the world on Saturday, October 14, 2023.

--- a/ONEWS.md
+++ b/ONEWS.md
@@ -1,0 +1,64 @@
+# MailPolicyExplainer Old News
+Everything old is new again!  If you have any historical interest in this module's development, here you go.  I'm not going to delete it, as I do than several people in here, and that should never get deleted.
+
+## Version 1.4.1
+This was released on Wednesday, May 22, 2024.  Friend of the module [Jason Berry](https://github.com/skyblaster) [found and corrected a bug](https://github.com/rhymeswithmogul/MailPolicyExplainer/pull/3) a bug where the DMARC percentage (the `pct` token) was not being explained.
+
+## Version 1.4.0
+This was released on Thursday, April 4, 2024.  It's dedicated to Mimi (2006-2024), the best cat and a very good girl.
+
+New features:
+ - Most cmdlets now have a `-DisableDnssecVerification` switch that will disable all DNSSEC checks.  While it is still a best practice, maybe your DNS host doesn't support it (for some reason) and you'd like this cmdlet not to nag you every time.  Note that DNSSEC checks are still done for DANE records, as the former is a prerequisite for the latter, whether this switch is specified or not.
+ - `Test-DkimRecord` will print the full DKIM TXT record to the verbose stream (i.e., the one that's visible when using `-Verbose` or setting the appropriate `$VerbosePreference` value).  Thanks to [Jason Berry](https://github.com/skyblaster) for writing [the pull request](https://github.com/rhymeswithmogul/MailPolicyExplainer/pull/1)!
+
+Two bugs were fixed:
+ - The SPF parser would sometimes show IPv4 addresses with a character prepended;  for example, "Accept mail from the IPv4 address +192.0.2.1" or "Reject mail from the IPv4 address -192.0.2.2".  This has been corrected by fixing the parser.
+ - DNSSEC status is now shown even when records are not found.  DNSSEC is checked even records do not exist, in what's called authenticated denial of existence, so we should communicate it to the user regardless.
+ - MTA-STS policy files are parsed to make sure they contain CR+LF line endings, but this did not work correctly on Windows PowerShell 5.1.  Thanks to [Jason Berry](https://github.com/skyblaster) for reporting it [and fixing it, too](https://github.com/rhymeswithmogul/MailPolicyExplainer/pull/2)!
+
+## Version 1.3.4
+This was released on Wednesday, January 24, 2024.
+
+This is a bugfix release.  Due to a tiny syntax error, this module was not loading on Windows PowerShell 5.1.  This has been corrected.  PowerShell 7 was not affected.  Thank you to Aslan Grealis for pointing this out.
+
+## Version 1.3.3
+This was released on Thursday, January 17, 2024.
+
+This is a bugfix release.  When no DANE records are present for a domain with a single MX host, `Test-DaneRecords` would erroneously report the domain name when it should have reported the MX server name.  For example, "DANE records are not present for contoso.com" instead of "DANE records are not present for mail.contoso.com".  The non-existence of DANE records was reported correctly, though the error message was confusing.
+
+## Version 1.3.2
+This was released on Friday, December 8, 2023.
+
+This is a bugfix release.  Now, `Test-MtaStsPolicy` no longer misidentifies `mta-sts.txt` files with the correct CRLF line endings as malformed.  This was caused by a regression in version 1.3.1.
+
+## Version 1.3.1
+This was released on Wednesday, December 6, 2023.
+
+The output of `Test-IPVersions` is now indented when run from `Test-MxRecord` or `Test-MailPolicy`.  This ought to make things a little easier to read.
+
+More importantly, almost a dozen bugs have been squashed!
+
+## Version 1.3.0
+This was released on Tuesdsay, November 7, 2023.
+
+The SPF test now supports a new parameter, `-CountDnsLookups`, to test an SPF record recursively to ensure that no more than ten additional DNS lookups are required to evaluate SPF for a domain.  This can be invoked by either `Test-SpfRecord -CountDnsLookups` or `Test-MailPolicy -CountSpfDnsLookups`.  (`-Recurse` is an easy-to-remember alias for both cmdlets).
+
+In addition, a few bugs have also been squished -- namely, one that prevented conceptual help from being made available.
+
+## Version 1.2.0
+This was also released on Thursday, October 19, 2023.
+
+The SPF test now follows the `redirect=` modifier's value.  For example, if domainA.com has `v=spf1 redirect=domainB.com`, the module will analyze domainB.com's SPF record.  (Previously, the `redirect=` test was non-functional.)  Note that this behavior was reversed in version 1.3.0.
+
+## Version 1.1.0
+This was released on Thursday, October 19, 2023.
+
+### New features
+MX records and MTA-STS policy servers are now checked to make sure they are reachable over both IPv4 and IPv6.  This will ensure that all Internet users, including those who only have one protocol, can still access your server.
+
+### Bug Fixes
+- DKIM records may safely omit the `v=DKIM1` and `k=rsa` tokens.  This module, however, did not recognize those as valid.  These default values are now allowed to be missing, and substituted with appropriate defaults, per the RFC.
+- DKIM RSA keys larger than 4,096 bits now generate a warning, as they are not required to be supported by all validators.
+
+## Version 1.0.0
+This module was first released to the world on Saturday, October 14, 2023.

--- a/en-US/MailPolicyExplainer-help.xml
+++ b/en-US/MailPolicyExplainer-help.xml
@@ -62,6 +62,18 @@
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="CD, DnssecCD, NoDnssec, DisableDnssec">
+        <maml:name>DisableDnssecVerification</maml:name>
+        <maml:description>
+          <maml:para>Disable DNSSEC validation.  This cmdlet will not request authenticated data from the resolver;  thus, DNSSEC validation of resource records will not occur, nor will the user be informed about unauthenticated denial of existence of DNS records.  Using this switch is NOT RECOMMENDED for production use and should only be used for diagnostic and troubleshooting purposes only!</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
         <maml:name>InputObject</maml:name>
         <maml:description>
@@ -85,18 +97,6 @@
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
-      </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="CD, DnssecCD, NoDnssec, DisableDnssec">
-        <maml:name>DisableDnssecVerification</maml:name>
-        <maml:description>
-          <maml:para>Disable DNSSEC validation.  This cmdlet will not request authenticated data from the resolver;  thus, DNSSEC validation of resource records will not occur, nor will the user be informed about unauthenticated denial of existence of DNS records.  Using this switch is NOT RECOMMENDED for production use and should only be used for diagnostic and troubleshooting purposes only!</maml:para>
-        </maml:description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes>
@@ -191,18 +191,6 @@
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
-        <maml:name>DomainName</maml:name>
-        <maml:description>
-          <maml:para>The domain name to test.  Be sure to include any applicable subdomains (i.e., "contoso.com" and "newsletters.contoso.com" are two different domains).</maml:para>
-        </maml:description>
-        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-        <dev:type>
-          <maml:name>String</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>None</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="CD, DnssecCD, NoDnssec, DisableDnssec">
         <maml:name>DisableDnssecVerification</maml:name>
         <maml:description>
@@ -214,6 +202,18 @@
           <maml:uri />
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+        <maml:name>DomainName</maml:name>
+        <maml:description>
+          <maml:para>The domain name to test.  Be sure to include any applicable subdomains (i.e., "contoso.com" and "newsletters.contoso.com" are two different domains).</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes>
@@ -322,6 +322,18 @@
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="CD, DnssecCD, NoDnssec, DisableDnssec">
+        <maml:name>DisableDnssecVerification</maml:name>
+        <maml:description>
+          <maml:para>Disable DNSSEC validation.  This cmdlet will not request authenticated data from the resolver;  thus, DNSSEC validation of resource records will not occur, nor will the user be informed about unauthenticated denial of existence of DNS records.  Using this switch is NOT RECOMMENDED for production use and should only be used for diagnostic and troubleshooting purposes only!</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
         <maml:name>DomainName</maml:name>
         <maml:description>
@@ -345,18 +357,6 @@
           <maml:uri />
         </dev:type>
         <dev:defaultValue>"default"</dev:defaultValue>
-      </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="CD, DnssecCD, NoDnssec, DisableDnssec">
-        <maml:name>DisableDnssecVerification</maml:name>
-        <maml:description>
-          <maml:para>Disable DNSSEC validation.  This cmdlet will not request authenticated data from the resolver;  thus, DNSSEC validation of resource records will not occur, nor will the user be informed about unauthenticated denial of existence of DNS records.  Using this switch is NOT RECOMMENDED for production use and should only be used for diagnostic and troubleshooting purposes only!</maml:para>
-        </maml:description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes>
@@ -596,6 +596,18 @@
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="CD, DnssecCD, NoDnssec, DisableDnssec">
+        <maml:name>DisableDnssecVerification</maml:name>
+        <maml:description>
+          <maml:para>Disable DNSSEC validation.  This cmdlet will not request authenticated data from the resolver;  thus, DNSSEC validation of resource records will not occur, nor will the user be informed about unauthenticated denial of existence of DNS records.  Using this switch is NOT RECOMMENDED for production use and should only be used for diagnostic and troubleshooting purposes only!</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
         <maml:name>DomainName</maml:name>
         <maml:description>
@@ -619,18 +631,6 @@
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
-      </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="CD, DnssecCD, NoDnssec, DisableDnssec">
-        <maml:name>DisableDnssecVerification</maml:name>
-        <maml:description>
-          <maml:para>Disable DNSSEC validation.  This cmdlet will not request authenticated data from the resolver;  thus, DNSSEC validation of resource records will not occur, nor will the user be informed about unauthenticated denial of existence of DNS records.  Using this switch is NOT RECOMMENDED for production use and should only be used for diagnostic and troubleshooting purposes only!</maml:para>
-        </maml:description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes>
@@ -742,18 +742,6 @@
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
-        <maml:name>DomainName</maml:name>
-        <maml:description>
-          <maml:para>The domain name to test.  Be sure to include any applicable subdomains (i.e., "contoso.com" and "newsletters.contoso.com" are two different domains).</maml:para>
-        </maml:description>
-        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-        <dev:type>
-          <maml:name>String</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>None</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="CD, DnssecCD, NoDnssec, DisableDnssec">
         <maml:name>DisableDnssecVerification</maml:name>
         <maml:description>
@@ -765,6 +753,18 @@
           <maml:uri />
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+        <maml:name>DomainName</maml:name>
+        <maml:description>
+          <maml:para>The domain name to test.  Be sure to include any applicable subdomains (i.e., "contoso.com" and "newsletters.contoso.com" are two different domains).</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes>
@@ -945,22 +945,10 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="bimi">
           <maml:name>BimiSelectorsToCheck</maml:name>
           <maml:description>
             <maml:para>The names of one or more DKIM selectors.  If omitted, no DKIM checks will be done.</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
-          <dev:type>
-            <maml:name>String[]</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>DkimSelectorsToCheck</maml:name>
-          <maml:description>
-            <maml:para>The names of one or more BIMI selectors.  If omitted, no BIMI checks will be done.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
           <dev:type>
@@ -991,10 +979,34 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="dkim">
+          <maml:name>DkimSelectorsToCheck</maml:name>
+          <maml:description>
+            <maml:para>The names of one or more BIMI selectors.  If omitted, no BIMI checks will be done.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="ExchangeOnline, Microsoft365, Microsoft365Dkim, Office365, Office365Dkim">
+          <maml:name>ExchangeOnlineDkim</maml:name>
+          <maml:description>
+            <maml:para>Check the DKIM selectors "selector1" and "selector2".  These are the two (and only two) used by Exchange Online.  You may also use the `-DkimSelectorsToCheck` parameter to check additional selectors.</maml:para>
+            <maml:para>This is functionally equivalent to `-DkimSelectorsToCheck "selector1","selector2"`.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="bimi">
         <maml:name>BimiSelectorsToCheck</maml:name>
         <maml:description>
           <maml:para>The names of one or more DKIM selectors.  If omitted, no DKIM checks will be done.</maml:para>
@@ -1006,7 +1018,31 @@
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="Recurse">
+        <maml:name>CountSpfDnsLookups</maml:name>
+        <maml:description>
+          <maml:para>Specify this switch to count how many additional DNS lookups are required to evaluate SPF.  The SPF test will run recursively to check all `redirect=` modifiers and `include:` tokens.  If more than ten additional DNS lookups are required, SPF parsers may choose to terminate and return a PermError.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="CD, DnssecCD, NoDnssec, DisableDnssec">
+        <maml:name>DisableDnssecVerification</maml:name>
+        <maml:description>
+          <maml:para>Disable DNSSEC validation.  This cmdlet will not request authenticated data from the resolver;  thus, DNSSEC validation of resource records will not occur, nor will the user be informed about unauthenticated denial of existence of DNS records.  Using this switch is NOT RECOMMENDED for production use and should only be used for diagnostic and troubleshooting purposes only!</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="dkim">
         <maml:name>DkimSelectorsToCheck</maml:name>
         <maml:description>
           <maml:para>The names of one or more BIMI selectors.  If omitted, no BIMI checks will be done.</maml:para>
@@ -1030,22 +1066,11 @@
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="Recurse">
-        <maml:name>CountSpfDnsLookups</maml:name>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="ExchangeOnline, Microsoft365, Microsoft365Dkim, Office365, Office365Dkim">
+        <maml:name>ExchangeOnlineDkim</maml:name>
         <maml:description>
-          <maml:para>Specify this switch to count how many additional DNS lookups are required to evaluate SPF.  The SPF test will run recursively to check all `redirect=` modifiers and `include:` tokens.  If more than ten additional DNS lookups are required, SPF parsers may choose to terminate and return a PermError.</maml:para>
-        </maml:description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="CD, DnssecCD, NoDnssec, DisableDnssec">
-        <maml:name>DisableDnssecVerification</maml:name>
-        <maml:description>
-          <maml:para>Disable DNSSEC validation.  This cmdlet will not request authenticated data from the resolver;  thus, DNSSEC validation of resource records will not occur, nor will the user be informed about unauthenticated denial of existence of DNS records.  Using this switch is NOT RECOMMENDED for production use and should only be used for diagnostic and troubleshooting purposes only!</maml:para>
+          <maml:para>Check the DKIM selectors "selector1" and "selector2".  These are the two (and only two) used by Exchange Online.  You may also use the `-DkimSelectorsToCheck` parameter to check additional selectors.</maml:para>
+          <maml:para>This is functionally equivalent to `-DkimSelectorsToCheck "selector1","selector2"`.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -1207,18 +1232,6 @@
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
-        <maml:name>DomainName</maml:name>
-        <maml:description>
-          <maml:para>The domain name to test.  Be sure to include any applicable subdomains (i.e., "contoso.com" and "newsletters.contoso.com" are two different domains).</maml:para>
-        </maml:description>
-        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-        <dev:type>
-          <maml:name>String</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>None</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="CD, DnssecCD, NoDnssec, DisableDnssec">
         <maml:name>DisableDnssecVerification</maml:name>
         <maml:description>
@@ -1230,6 +1243,18 @@
           <maml:uri />
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+        <maml:name>DomainName</maml:name>
+        <maml:description>
+          <maml:para>The domain name to test.  Be sure to include any applicable subdomains (i.e., "contoso.com" and "newsletters.contoso.com" are two different domains).</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes>
@@ -1327,18 +1352,6 @@
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
-        <maml:name>DomainName</maml:name>
-        <maml:description>
-          <maml:para>The domain name to test.  Be sure to include any applicable subdomains (i.e., "contoso.com" and "newsletters.contoso.com" are two different domains).</maml:para>
-        </maml:description>
-        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-        <dev:type>
-          <maml:name>String</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>None</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="CD, DnssecCD, NoDnssec, DisableDnssec">
         <maml:name>DisableDnssecVerification</maml:name>
         <maml:description>
@@ -1350,6 +1363,18 @@
           <maml:uri />
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+        <maml:name>DomainName</maml:name>
+        <maml:description>
+          <maml:para>The domain name to test.  Be sure to include any applicable subdomains (i.e., "contoso.com" and "newsletters.contoso.com" are two different domains).</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes>
@@ -1447,18 +1472,6 @@
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
-        <maml:name>DomainName</maml:name>
-        <maml:description>
-          <maml:para>The domain name to test.  Be sure to include any applicable subdomains (i.e., "contoso.com" and "newsletters.contoso.com" are two different domains).</maml:para>
-        </maml:description>
-        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-        <dev:type>
-          <maml:name>String</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>None</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="CD, DnssecCD, NoDnssec, DisableDnssec">
         <maml:name>DisableDnssecVerification</maml:name>
         <maml:description>
@@ -1470,6 +1483,18 @@
           <maml:uri />
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+        <maml:name>DomainName</maml:name>
+        <maml:description>
+          <maml:para>The domain name to test.  Be sure to include any applicable subdomains (i.e., "contoso.com" and "newsletters.contoso.com" are two different domains).</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes>
@@ -1539,7 +1564,7 @@
       <maml:para>Sender Policy Framework (RFC 7208) is a DNS TXT record at the root of a DNS zone that lets a domain define its legitimate sources of email.  It can contain IP addresses, domain names, or even other SPF records.</maml:para>
       <maml:para>SPF provides a complementary authentication to DKIM, and is a requirement for implementing DMARC.</maml:para>
       <maml:para>In the past, SPF records had their own DNS resource record type, also called "SPF".  SPF records of type SPF are now historic, and the DNS TXT record should be used.</maml:para>
-      <maml:para>In addition, Microsoft briefly tried to create Sender ID, a very similar DNS record that started with "spf2.0".  That is historic and no longer in use.</maml:para>
+      <maml:para>In addition, Microsoft briefly tried to create Sender ID, a very similar DNS record that started with "spf2.0".  That is historic and no longer in use.  However, it can still be tested by invoking this as `Test-SenderIdRecord`.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -1582,18 +1607,6 @@
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="Name">
-        <maml:name>DomainName</maml:name>
-        <maml:description>
-          <maml:para>The domain name to test.  Be sure to include any applicable subdomains (i.e., "contoso.com" and "newsletters.contoso.com" are two different domains).</maml:para>
-        </maml:description>
-        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-        <dev:type>
-          <maml:name>String</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>None</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="Recurse, CountSpfDnsLookups">
         <maml:name>CountDnsLookups</maml:name>
         <maml:description>
@@ -1618,6 +1631,18 @@
           <maml:uri />
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="Name">
+        <maml:name>DomainName</maml:name>
+        <maml:description>
+          <maml:para>The domain name to test.  Be sure to include any applicable subdomains (i.e., "contoso.com" and "newsletters.contoso.com" are two different domains).</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes>
@@ -1658,6 +1683,13 @@
         <dev:code>PS C:\&gt;  Test-SpfRecord lucernepublishing.com -CountDnsLookups</dev:code>
         <dev:remarks>
           <maml:para>Tests the SPF record for lucernepublishing.com, evaluating it recursively and counting how many additional DNS lookups are performed.  This resolves the DNS TXT record "lucernepublishing.com" and any other SPF records referenced by any "redirect" modifiers or "include" tokens.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- Example 3 --------------------------</maml:title>
+        <dev:code>PS C:\&gt;  Test-SenderIdRecord woodgrovebank.com</dev:code>
+        <dev:remarks>
+          <maml:para>Tests the Sender ID records for woodgrovebank.com.  This resolves the DNS TXT record "woodgrovebank.com".</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>

--- a/man/en-US/Invoke-GooglePublicDnsApi.md
+++ b/man/en-US/Invoke-GooglePublicDnsApi.md
@@ -30,6 +30,21 @@ Fetches the DNSSEC-validated DMARC record for contoso.com.
 
 ## PARAMETERS
 
+### -DisableDnssecVerification
+Disable DNSSEC validation.  This cmdlet will not request authenticated data from the resolver;  thus, DNSSEC validation of resource records will not occur, nor will the user be informed about unauthenticated denial of existence of DNS records.  Using this switch is NOT RECOMMENDED for production use and should only be used for diagnostic and troubleshooting purposes only!
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: CD, DnssecCD, NoDnssec, DisableDnssec
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -InputObject
 The fully-qualified domain name that will be looked up.  You do not need to specify a trailing period.
 
@@ -56,21 +71,6 @@ Accepted values: A, AAAA, CNAME, MX, SPF, TLSA, TXT
 
 Required: False
 Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -DisableDnssecVerification
-Disable DNSSEC validation.  This cmdlet will not request authenticated data from the resolver;  thus, DNSSEC validation of resource records will not occur, nor will the user be informed about unauthenticated denial of existence of DNS records.  Using this switch is NOT RECOMMENDED for production use and should only be used for diagnostic and troubleshooting purposes only!
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: CD, DnssecCD, NoDnssec, DisableDnssec
-
-Required: False
-Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/man/en-US/Test-AdspRecord.md
+++ b/man/en-US/Test-AdspRecord.md
@@ -36,21 +36,6 @@ Tests the DNS TXT record "_adsp._domainkey.contoso.com".
 
 ## PARAMETERS
 
-### -DomainName
-The domain name to test.  Be sure to include any applicable subdomains (i.e., "contoso.com" and "newsletters.contoso.com" are two different domains).
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 0
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -DisableDnssecVerification
 Disable DNSSEC validation.  This cmdlet will not request authenticated data from the resolver;  thus, DNSSEC validation of resource records will not occur, nor will the user be informed about unauthenticated denial of existence of DNS records.  Using this switch is NOT RECOMMENDED for production use and should only be used for diagnostic and troubleshooting purposes only!
 
@@ -61,6 +46,21 @@ Aliases: CD, DnssecCD, NoDnssec, DisableDnssec
 
 Required: False
 Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DomainName
+The domain name to test.  Be sure to include any applicable subdomains (i.e., "contoso.com" and "newsletters.contoso.com" are two different domains).
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/man/en-US/Test-BimiSelector.md
+++ b/man/en-US/Test-BimiSelector.md
@@ -51,6 +51,21 @@ Tests the BIMI selector named "tailspintoys" present for contoso.com.  The DNS T
 
 ## PARAMETERS
 
+### -DisableDnssecVerification
+Disable DNSSEC validation.  This cmdlet will not request authenticated data from the resolver;  thus, DNSSEC validation of resource records will not occur, nor will the user be informed about unauthenticated denial of existence of DNS records.  Using this switch is NOT RECOMMENDED for production use and should only be used for diagnostic and troubleshooting purposes only!
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: CD, DnssecCD, NoDnssec, DisableDnssec
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -DomainName
 The domain name whose BIMI selector you wish to test.  Be sure to include any applicable subdomains (i.e., "contoso.com" and "newsletters.contoso.com" are two different domains).
 
@@ -77,21 +92,6 @@ Aliases: Selector, SelectorName
 Required: False
 Position: 1
 Default value: "default"
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -DisableDnssecVerification
-Disable DNSSEC validation.  This cmdlet will not request authenticated data from the resolver;  thus, DNSSEC validation of resource records will not occur, nor will the user be informed about unauthenticated denial of existence of DNS records.  Using this switch is NOT RECOMMENDED for production use and should only be used for diagnostic and troubleshooting purposes only!
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: CD, DnssecCD, NoDnssec, DisableDnssec
-
-Required: False
-Position: Named
-Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/man/en-US/Test-DkimSelector.md
+++ b/man/en-US/Test-DkimSelector.md
@@ -43,6 +43,21 @@ Tests shop.fabrikam.com's DKIM selector named "receipts".  The DNS TXT record to
 
 ## PARAMETERS
 
+### -DisableDnssecVerification
+Disable DNSSEC validation.  This cmdlet will not request authenticated data from the resolver;  thus, DNSSEC validation of resource records will not occur, nor will the user be informed about unauthenticated denial of existence of DNS records.  Using this switch is NOT RECOMMENDED for production use and should only be used for diagnostic and troubleshooting purposes only!
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: CD, DnssecCD, NoDnssec, DisableDnssec
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -DomainName
 The domain name to test.  Be sure to include any applicable subdomains (i.e., "contoso.com" and "newsletters.contoso.com" are two different domains).
 
@@ -68,21 +83,6 @@ Aliases: Selector, SelectorName, KeyName
 
 Required: True
 Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -DisableDnssecVerification
-Disable DNSSEC validation.  This cmdlet will not request authenticated data from the resolver;  thus, DNSSEC validation of resource records will not occur, nor will the user be informed about unauthenticated denial of existence of DNS records.  Using this switch is NOT RECOMMENDED for production use and should only be used for diagnostic and troubleshooting purposes only!
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: CD, DnssecCD, NoDnssec, DisableDnssec
-
-Required: False
-Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/man/en-US/Test-DmarcRecord.md
+++ b/man/en-US/Test-DmarcRecord.md
@@ -36,21 +36,6 @@ Tests the DMARC record for contoso.com.  The DNS TXT record to be resolved is "_
 
 ## PARAMETERS
 
-### -DomainName
-The domain name to test.  Be sure to include any applicable subdomains (i.e., "contoso.com" and "newsletters.contoso.com" are two different domains).
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 0
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -DisableDnssecVerification
 Disable DNSSEC validation.  This cmdlet will not request authenticated data from the resolver;  thus, DNSSEC validation of resource records will not occur, nor will the user be informed about unauthenticated denial of existence of DNS records.  Using this switch is NOT RECOMMENDED for production use and should only be used for diagnostic and troubleshooting purposes only!
 
@@ -61,6 +46,21 @@ Aliases: CD, DnssecCD, NoDnssec, DisableDnssec
 
 Required: False
 Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DomainName
+The domain name to test.  Be sure to include any applicable subdomains (i.e., "contoso.com" and "newsletters.contoso.com" are two different domains).
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/man/en-US/Test-MXRecord.md
+++ b/man/en-US/Test-MXRecord.md
@@ -32,21 +32,6 @@ Tests the DNS MX records (if they exist) for "contoso.com."
 
 ## PARAMETERS
 
-### -DomainName
-The domain name to test.  Be sure to include any applicable subdomains (i.e., "contoso.com" and "newsletters.contoso.com" are two different domains).
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 0
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -DisableDnssecVerification
 Disable DNSSEC validation.  This cmdlet will not request authenticated data from the resolver;  thus, DNSSEC validation of resource records will not occur, nor will the user be informed about unauthenticated denial of existence of DNS records.  Using this switch is NOT RECOMMENDED for production use and should only be used for diagnostic and troubleshooting purposes only!
 
@@ -57,6 +42,21 @@ Aliases: CD, DnssecCD, NoDnssec, DisableDnssec
 
 Required: False
 Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DomainName
+The domain name to test.  Be sure to include any applicable subdomains (i.e., "contoso.com" and "newsletters.contoso.com" are two different domains).
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/man/en-US/Test-MailPolicy.md
+++ b/man/en-US/Test-MailPolicy.md
@@ -14,7 +14,8 @@ Tests all email-related DNS records for a domain.
 
 ```
 Test-MailPolicy [-DomainName] <String> [-CountSpfDnsLookups] [-DkimSelectorsToCheck <String[]>]
- [-BimiSelectorsToCheck <String[]>] [-DisableDnssecVerification] [<CommonParameters>]
+ [-ExchangeOnlineDkim] [-BimiSelectorsToCheck <String[]>] [-DisableDnssecVerification]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -58,40 +59,10 @@ The names of one or more DKIM selectors.  If omitted, no DKIM checks will be don
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases:
+Aliases: bimi
 
 Required: False
 Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -DkimSelectorsToCheck
-The names of one or more BIMI selectors.  If omitted, no BIMI checks will be done.
-
-```yaml
-Type: String[]
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -DomainName
-The domain name to test.  Be sure to include any applicable subdomains (i.e., "contoso.com" and "newsletters.contoso.com" are two different domains).
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -119,6 +90,53 @@ Disable DNSSEC validation.  This cmdlet will not request authenticated data from
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: CD, DnssecCD, NoDnssec, DisableDnssec
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DkimSelectorsToCheck
+The names of one or more BIMI selectors.  If omitted, no BIMI checks will be done.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases: dkim
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DomainName
+The domain name to test.  Be sure to include any applicable subdomains (i.e., "contoso.com" and "newsletters.contoso.com" are two different domains).
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExchangeOnlineDkim
+Check the DKIM selectors "selector1" and "selector2".  These are the two (and only two) used by Exchange Online.  You may also use the `-DkimSelectorsToCheck` parameter to check additional selectors.
+
+This is functionally equivalent to `-DkimSelectorsToCheck "selector1","selector2"`.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: ExchangeOnline, Microsoft365, Microsoft365Dkim, Office365, Office365Dkim
 
 Required: False
 Position: Named

--- a/man/en-US/Test-MtaStsPolicy.md
+++ b/man/en-US/Test-MtaStsPolicy.md
@@ -38,21 +38,6 @@ This will evaluate the MTA-STS policy for contoso.com.  It will look up the DNS 
 
 ## PARAMETERS
 
-### -DomainName
-The domain name to test.  Be sure to include any applicable subdomains (i.e., "contoso.com" and "newsletters.contoso.com" are two different domains).
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 0
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -DisableDnssecVerification
 Disable DNSSEC validation.  This cmdlet will not request authenticated data from the resolver;  thus, DNSSEC validation of resource records will not occur, nor will the user be informed about unauthenticated denial of existence of DNS records.  Using this switch is NOT RECOMMENDED for production use and should only be used for diagnostic and troubleshooting purposes only!
 
@@ -63,6 +48,21 @@ Aliases: CD, DnssecCD, NoDnssec, DisableDnssec
 
 Required: False
 Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DomainName
+The domain name to test.  Be sure to include any applicable subdomains (i.e., "contoso.com" and "newsletters.contoso.com" are two different domains).
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/man/en-US/Test-SmtpTlsReportingPolicy.md
+++ b/man/en-US/Test-SmtpTlsReportingPolicy.md
@@ -32,21 +32,6 @@ Tests the SMTP TLS reporting policy for contoso.com.  This resolves the DNS TXT 
 
 ## PARAMETERS
 
-### -DomainName
-The domain name to test.  Be sure to include any applicable subdomains (i.e., "contoso.com" and "newsletters.contoso.com" are two different domains).
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 0
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -DisableDnssecVerification
 Disable DNSSEC validation.  This cmdlet will not request authenticated data from the resolver;  thus, DNSSEC validation of resource records will not occur, nor will the user be informed about unauthenticated denial of existence of DNS records.  Using this switch is NOT RECOMMENDED for production use and should only be used for diagnostic and troubleshooting purposes only!
 
@@ -57,6 +42,21 @@ Aliases: CD, DnssecCD, NoDnssec, DisableDnssec
 
 Required: False
 Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DomainName
+The domain name to test.  Be sure to include any applicable subdomains (i.e., "contoso.com" and "newsletters.contoso.com" are two different domains).
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/man/en-US/Test-SpfRecord.md
+++ b/man/en-US/Test-SpfRecord.md
@@ -13,8 +13,7 @@ Tests and explains a domain's SPF record.
 ## SYNTAX
 
 ```
-Test-SpfRecord [-DomainName] <String> [-CountDnsLookups] [-DisableDnssecVerification]
- [-Recursions <PSReference>] [-DnsLookups <PSReference>] [<CommonParameters>]
+Test-SpfRecord [-DomainName] <String> [-CountDnsLookups] [-DisableDnssecVerification] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -26,7 +25,7 @@ SPF provides a complementary authentication to DKIM, and is a requirement for im
 
 In the past, SPF records had their own DNS resource record type, also called "SPF".  SPF records of type SPF are now historic, and the DNS TXT record should be used.
 
-In addition, Microsoft briefly tried to create Sender ID, a very similar DNS record that started with "spf2.0".  That is historic and no longer in use.
+In addition, Microsoft briefly tried to create Sender ID, a very similar DNS record that started with "spf2.0".  That is historic and no longer in use.  However, it can still be tested by invoking this as `Test-SenderIdRecord`.
 
 ## EXAMPLES
 
@@ -44,22 +43,14 @@ PS C:\>  Test-SpfRecord lucernepublishing.com -CountDnsLookups
 
 Tests the SPF record for lucernepublishing.com, evaluating it recursively and counting how many additional DNS lookups are performed.  This resolves the DNS TXT record "lucernepublishing.com" and any other SPF records referenced by any "redirect" modifiers or "include" tokens.
 
-## PARAMETERS
-
-### -DomainName
-The domain name to test.  Be sure to include any applicable subdomains (i.e., "contoso.com" and "newsletters.contoso.com" are two different domains).
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: Name
-
-Required: True
-Position: 0
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
+### Example 3
+```powershell
+PS C:\>  Test-SenderIdRecord woodgrovebank.com
 ```
+
+Tests the Sender ID records for woodgrovebank.com.  This resolves the DNS TXT record "woodgrovebank.com".
+
+## PARAMETERS
 
 ### -CountDnsLookups
 Specify this parameter to count how many DNS lookups are required to evaluate this SPF record, to make sure it isn't over the limit of ten additional lookups, after which point, SPF evaluators may choose to stop processing and return a PermError.  This switch will cause this cmdlet to operate recursively, and evaluate any SPF records found via the "redirect" modifier and the "include" token.
@@ -88,6 +79,21 @@ Aliases: CD, DnssecCD, NoDnssec, DisableDnssec
 
 Required: False
 Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DomainName
+The domain name to test.  Be sure to include any applicable subdomains (i.e., "contoso.com" and "newsletters.contoso.com" are two different domains).
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Name
+
+Required: True
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/src/MailPolicyExplainer.psm1
+++ b/src/MailPolicyExplainer.psm1
@@ -844,8 +844,13 @@ Function Test-MailPolicy
 		[Alias('Recurse')]
 		[Switch] $CountSpfDnsLookups,
 
+		[Alias('dkim')]
 		[String[]] $DkimSelectorsToCheck,
 
+		[Alias('ExchangeOnline', 'Microsoft365', 'Microsoft365Dkim', 'Office365', 'Office365Dkim')]
+		[Switch] $ExchangeOnlineDkim,
+
+		[Alias('bimi')]
 		[String[]] $BimiSelectorsToCheck,
 
 		[Alias('CD', 'DnssecCD', 'NoDnssec', 'DisableDnssec')]
@@ -855,6 +860,15 @@ Function Test-MailPolicy
 	Write-Output "Analyzing email records for $DomainName"
 	Test-MXRecord $DomainName -DisableDnssecVerification:$DisableDnssecVerification
 	Test-SpfRecord $DomainName -Recurse:$CountSpfDnsLookups -DisableDnssecVerification:$DisableDnssecVerification
+	If ($ExchangeOnlineDkim) {
+		$x = @('selector1', 'selector2')
+		ForEach ($selector in $DkimSelectorsToCheck) {
+			If ($selector -ne 'selector1' -and $selector -ne 'selector2') {
+				$x += $selector
+			}
+		}
+		$DkimSelectorsToCheck = $x
+	}
 	If ($DkimSelectorsToCheck.Count -gt 0) {
 		$DkimSelectorsToCheck | ForEach-Object {
 			Test-DkimSelector $DomainName -Name $_ -DisableDnssecVerification:$DisableDnssecVerification
@@ -1335,8 +1349,8 @@ Function Test-SpfRecord
 	}
 
 	# Add indentation when doing recursive SPF lookups.
+	$RecordTypePrintable = $RecordType -Split '─' | Select-Object -Last 1
 	If ($CountDnsLookups) {
-		$RecordTypePrintable = $RecordType -Split '─' | Select-Object -Last 1
 		$RecordType = "$('├──' * $Recursions.Value)$RecordType"
 	}
 	#endregion


### PR DESCRIPTION
This commit was an idea I've been mulling over for a while.  There is now a `Test-MailPolicy -ExchangeOnline` parameter. This is the same as `Test-MailPolicy -DkimSelectorsToCheck selector1,selector2`. Of course, this doesn't prevent you from also using `-DkimSelectorsToCheck` to check additional selectors at the same time.

Shout out to the thousands of Exchange Online administrators and support staff, including the dozens that I work with.  You're welcome.

Closes: #6